### PR TITLE
api: disable tracking when events not deployed

### DIFF
--- a/deploy/complete/helm-chart/mushop/charts/api/templates/_helpers.tpl
+++ b/deploy/complete/helm-chart/mushop/charts/api/templates/_helpers.tpl
@@ -59,6 +59,11 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
       key: zipkin_path
 {{- end -}}
 
+{{- define "api.streaming" -}}
+- name: TRACKING_ENABLED
+  value: {{ .Values.env.trackingEnabled | quote }}
+{{- end -}}
+
 {{/* OIMS configuration */}}
 {{- define "api.oims.config" -}}
 {{- $ociDeployment := .Values.ociDeploymentConfigMap | default (.Values.global.ociDeploymentConfigMap | default (printf "%s-oci-deployment" .Chart.Name)) -}}

--- a/deploy/complete/helm-chart/mushop/charts/api/templates/api-deployment.yaml
+++ b/deploy/complete/helm-chart/mushop/charts/api/templates/api-deployment.yaml
@@ -29,18 +29,16 @@ spec:
             - containerPort: 8080
           livenessProbe:
             httpGet:
-              path: /health
+              path: /health/liveness
               port: 8080
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/readiness
               port: 8080
           env:
             {{- include "api.oapm.connection" . | nindent 12 }}
             {{- include "api.oims.config" . | nindent 12 }}
+            {{- include "api.streaming" . | nindent 12 }}
             - name: REDIS_URI
               value: redis://mushop-session:6379
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+

--- a/deploy/complete/helm-chart/mushop/charts/api/values.yaml
+++ b/deploy/complete/helm-chart/mushop/charts/api/values.yaml
@@ -6,6 +6,7 @@ image:
   pullPolicy: Always
 
 env:
+  trackingEnabled: false
   mediaUrl: /assets
   newsletterSubscribeUrl:
 

--- a/deploy/complete/helm-chart/mushop/values-dev.yaml
+++ b/deploy/complete/helm-chart/mushop/values-dev.yaml
@@ -12,6 +12,7 @@ ingress:
 
 api:
   env:
+    trackingEnabled:          # Flag that enables sending of tracking events to events service. If event service is not deployed set to "false".
     mediaUrl:                 # URL for catalog image assets (https://objectstorage.[REGION].oraclecloud.com/n/[NAMESPACE]/b/[BUCKET_NAME]/o/)
     newsletterSubscribeUrl:   # Newsletter subscription endpoint (https://[API_GATEWAY_URL]/newsletter/subscribe)
 

--- a/deploy/complete/helm-chart/mushop/values-prod-reference.yaml
+++ b/deploy/complete/helm-chart/mushop/values-prod-reference.yaml
@@ -32,5 +32,6 @@ ingress:
 
 api:
   env:
+    trackingEnabled:          # Flag that enables sending of tracking events to events service. If event service is not deployed set to "false".
     mediaUrl:                 # Object Storage URL for catalog image assets
     newsletterSubscribeUrl:   # Newsletter subscription endpoint (https://[API_GATEWAY_URL]/newsletter/subscribe)

--- a/deploy/complete/helm-chart/mushop/values-prod.yaml
+++ b/deploy/complete/helm-chart/mushop/values-prod.yaml
@@ -24,5 +24,6 @@ ingress:
 
 api:
   env:
+    trackingEnabled:          # Flag that enables sending of tracking events to events service. If event service is not deployed set to "false".
     mediaUrl:                 # Object Storage URL for catalog image assets
     newsletterSubscribeUrl:   # Newsletter subscription endpoint (https://[API_GATEWAY_URL]/newsletter/subscribe)

--- a/deploy/complete/helm-chart/mushop/values.yaml
+++ b/deploy/complete/helm-chart/mushop/values.yaml
@@ -24,6 +24,8 @@ ingress:
 
 api:
   enabled: true
+  env:
+    trackingEnabled: true
 
 assets:
   enabled: true

--- a/deploy/complete/terraform/mushop.tf
+++ b/deploy/complete/terraform/mushop.tf
@@ -49,6 +49,10 @@ resource "helm_release" "mushop" {
     name  = "global.test"
     value = var.oci_deployment
   }
+  set {
+    name  = "api.env.trackingEnabled"
+    value = var.create_oracle_streaming_service_stream ? true : false
+  }
   # set {
   #   name  = "global.oosBucketSecret" # Commented until come with solution to gracefull removal of objects when terraform destroy
   #   value = var.oos_bucket_name

--- a/src/api/src/main/java/api/services/support/TrackEventFilter.java
+++ b/src/api/src/main/java/api/services/support/TrackEventFilter.java
@@ -3,7 +3,9 @@ package api.services.support;
 import api.model.Event;
 import api.services.EventsService;
 import api.services.annotation.TrackEvent;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
@@ -20,6 +22,7 @@ import org.reactivestreams.Publisher;
 
 import java.util.Collections;
 
+@Requires(property = "tracking.enabled", notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
 @Filter(Filter.MATCH_ALL_PATTERN)
 public class TrackEventFilter implements HttpServerFilter {
     private final EventsService eventsService;


### PR DESCRIPTION
In case the events were not deployed the server TrackEventFilter tries to
send the tracking event to events service. In K8s environment this means
the EventService client hostname is resolved by K8s DiscoveryClient
that uses K8s client with @Retryable(attempts = "5", multiplier = "2.0")
, what means it takes half a minute to fail -> so the user response is
deleyed by this.

@graemerocher I was thinking about sending the tracking request to events service completely asynchronously
and in case of failed attempt to discover failed mushop-events service to disable the tracking (doOnError). However
this could disable the tracking even when redeploying events service. So instead of this I  just added plain old configuration option. Ideally we could leverage some messaging system with event retention time. 