### PR TITLE
Adding @Cacheable annotation to catalogue project.

### DIFF
--- a/src/catalogue/build.gradle
+++ b/src/catalogue/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 
     runtimeOnly("ch.qos.logback:logback-classic")
 
+    // Caching
+    implementation("io.micronaut.cache:micronaut-cache-caffeine:2.4.0")
+
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:oracle-xe")
     testImplementation("org.testcontainers:testcontainers")

--- a/src/catalogue/src/main/java/catalogue/controllers/CatalogueController.java
+++ b/src/catalogue/src/main/java/catalogue/controllers/CatalogueController.java
@@ -6,6 +6,7 @@ import catalogue.repositories.CategoryRepository;
 import catalogue.repositories.ProductRepository;
 import io.micrometer.core.annotation.Timed;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.cache.annotation.Cacheable;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
@@ -45,6 +46,7 @@ class CatalogueController implements CatalogueOperations {
     @Get("/categories")
     @Timed("category.list")
     @CircuitBreaker(reset = "30s")
+    @Cacheable
     public CategoriesDTO listCategories() {
         return new CategoriesDTO(categoryRepository.listName());
     }

--- a/src/catalogue/src/main/java/catalogue/controllers/CatalogueController.java
+++ b/src/catalogue/src/main/java/catalogue/controllers/CatalogueController.java
@@ -46,7 +46,7 @@ class CatalogueController implements CatalogueOperations {
     @Get("/categories")
     @Timed("category.list")
     @CircuitBreaker(reset = "30s")
-    @Cacheable
+    @Cacheable("categories")
     public CategoriesDTO listCategories() {
         return new CategoriesDTO(categoryRepository.listName());
     }

--- a/src/catalogue/src/main/resources/application.yml
+++ b/src/catalogue/src/main/resources/application.yml
@@ -16,6 +16,9 @@ micronaut:
       swagger:
         paths: classpath:META-INF/swagger
         mapping: /swagger/**
+  caches:
+    categories:
+      initial-capacity: 20
   metrics:
     export:
       prometheus:
@@ -24,6 +27,9 @@ micronaut:
         step: PT1M
       oraclecloud:
         enabled: false
+    binders:
+      cache:
+        enabled: true
     enabled: true
   data:
     pageable:

--- a/src/catalogue/src/test/java/catalogue/ProductControllerTest.java
+++ b/src/catalogue/src/test/java/catalogue/ProductControllerTest.java
@@ -3,6 +3,7 @@ package catalogue;
 import catalogue.controllers.CatalogueItemDTO;
 import catalogue.controllers.CatalogueOperations;
 import catalogue.controllers.CatalogueSizeDTO;
+import catalogue.controllers.CategoriesDTO;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.http.annotation.Get;
@@ -68,6 +69,23 @@ public class ProductControllerTest {
 
         final Optional<CatalogueItemDTO> garbage = client.find("garbage");
         assertFalse(garbage.isPresent());
+    }
+
+    @Test
+    void testListCategories() {
+        CategoriesDTO results = client.listCategories();
+
+        assertEquals(
+                15,
+                results.getCategories().length
+        );
+
+        results = client.listCategories();
+
+        assertEquals(
+                15,
+                results.getCategories().length
+        );
     }
 
     @Client("/")


### PR DESCRIPTION
This PR adds a @Cacheable annotation to the `catalogue` project as a first starting point to using Micronaut caches.

The particular method to annotate with @Cacheable (`listCategories`) seems to return a constant list of objects which look like a good candidate for caching (suggested by @graemerocher ).